### PR TITLE
feat: use GIT_KEY_BASE64 as secret in sd.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # sd-packages
 Kata custom kernel, custom os, Skopeo, ztsd binary build pipeline
+
+## Dependencies
+1. skopeo is a command line utility that performs various operations on container images and image repositories.
+LICENSE:https://github.com/containers/skopeo/blob/master/LICENSE
+2. Zstandard, or zstd as short version, is a fast lossless compression algorithm, targeting real-time compression scenarios at zlib-level and better compression ratios
+LICENSE:https://github.com/facebook/zstd/blob/dev/LICENSE

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -65,10 +65,10 @@ jobs:
       - package: tar -C dist -cvzf $RELEASE_FILE .
       - publish: ./ci/git-release.sh
     secrets:
-        # Pushing tags to Git
-        - GIT_KEY
-        # Pushing releases to GitHub
-        - GITHUB_TOKEN
+      # Pushing tags to Git
+      - GIT_KEY_BASE64
+      # Pushing releases to GitHub
+      - GITHUB_TOKEN
 
   zstd-build:
     requires: [~pr, ~commit]
@@ -94,14 +94,13 @@ jobs:
       - get: |
           store-cli get ./${ZSTD_PACKAGE} --type=cache --scope=event
           ls -lrt ./${ZSTD_PACKAGE}
-          chmod +x ./${ZSTD_PACKAGE}
           ./${ZSTD_PACKAGE} -v
       - tag: ./ci/git-tag.sh
       - package: tar -C dist -cvzf $RELEASE_FILE .
       - publish: ./ci/git-release.sh
     secrets:
-    # Pushing tags to Git
-    - GIT_KEY
-    # Pushing releases to GitHub
-    - GITHUB_TOKEN
+      # Pushing tags to Git
+      - GIT_KEY_BASE64
+      # Pushing releases to GitHub
+      - GITHUB_TOKEN
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-  image: node:12
+  image: centos:centos7
   environment:
     SKOPEO_PACKAGE: skopeo
     ZSTD_PACKAGE: zstd
@@ -8,7 +8,6 @@ shared:
 jobs:
   skopeo-build:
     requires: [~pr, ~commit]
-    image: centos:centos7
     steps:
       - make: |
           yum install -y epel-release
@@ -53,6 +52,7 @@ jobs:
 
   skopeo-publish:
     requires: [~skopeo-test]
+    image: node:12
     environment:
       RELEASE_FILE: skopeo-linux.tar.gz
     steps:
@@ -72,7 +72,6 @@ jobs:
 
   zstd-build:
     requires: [~pr, ~commit]
-    image: centos:centos7
     steps:
       - make: |
           yum install -y epel-release
@@ -87,6 +86,7 @@ jobs:
 
   zstd-publish:
     requires: [~zstd-build]
+    image: node:12
     environment:
       RELEASE_FILE : zstd-cli-linux.tar.gz
     steps:
@@ -94,6 +94,7 @@ jobs:
       - get: |
           store-cli get ./${ZSTD_PACKAGE} --type=cache --scope=event
           ls -lrt ./${ZSTD_PACKAGE}
+          chmod +x ./${ZSTD_PACKAGE}
           ./${ZSTD_PACKAGE} -v
       - tag: ./ci/git-tag.sh
       - package: tar -C dist -cvzf $RELEASE_FILE .


### PR DESCRIPTION
## Context

sd.yaml needs secrets key to publish git release

## Objective

Use GIT_KEY_BASE64 as secret env var to publish release

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
