### PR TITLE
feat: use multi file git release

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -66,7 +66,8 @@ jobs:
           yum install -y wget git make gcc gcc-c++ bzip2
           git clone https://github.com/screwdriver-cd/toolbox.git ci
       - tag: ./ci/git-tag.sh
-      - publish: ([ ! -z $SD_PULL_REQUEST ] && echo skip publish for PR) || (files=($RELEASE_FILES); for i in "${files[@]}"; do store-cli get $i --type=cache --scope=event; (if [ -f $i ]; then export RELEASE_FILE=$i && ./ci/git-release.sh; else echo skip $i not found; fi); done)
+      - get: (files=($RELEASE_FILES); for i in "${files[@]}"; do store-cli get $i --type=cache --scope=event;done)
+      - publish: ([ ! -z $SD_PULL_REQUEST ] && echo skip publish for PR) || ./ci/git-release.sh
     secrets:
       # Pushing tags to Git
       - GIT_KEY_BASE64


### PR DESCRIPTION
## Context

We need to publish binaries for launcher dependencies

## Objective

This PR will use the multiple file release feature from toolbox[https://github.com/screwdriver-cd/toolbox/pull/23]

## References
https://github.com/containers/skopeo/blob/master/install.md#building-from-source
https://github.com/facebook/zstd#build-instructions
https://github.com/screwdriver-cd/screwdriver/issues/2450

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
