### PR TITLE
Update screwdriver.yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -75,7 +75,9 @@ jobs:
           git clone https://github.com/screwdriver-cd/toolbox.git ci
       - get: (files=($RELEASE_FILES); for i in "${files[@]}"; do store-cli get $i --type=cache --scope=event;done)
       - tag: ./ci/git-tag.sh
-      - publish: ([ ! -z $SD_PULL_REQUEST ] && echo skip publish for PR) || ./ci/git-release.sh
+      - publish: |
+          git fetch --unshallow
+          ([ ! -z $SD_PULL_REQUEST ] && echo skip publish for PR) || ./ci/git-release.sh
     secrets:
       # Pushing tags to Git
       - GIT_KEY_BASE64


### PR DESCRIPTION
## Context

Try to fix the failed release `error: could not find the release corresponding to tag v0.0.32`

## Objective

Try to fix the failed release `error: could not find the release corresponding to tag v0.0.32`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
