### PR TITLE
publish aarch64 version for ztsd

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -62,9 +62,10 @@ jobs:
     requires: [~pr, ~commit]
     environment:
       ZSTD_PACKAGE: zstd
+      ZTSD_MAC_RELEASE_FILES: "zstd-cli-macosx.tar.gz"
     steps:
       - make: echo "Fetching local file for mac build. Please build and upload manually if building new version"
-      - package: a=($RELEASE_FILES) && store-cli set ${a[2]} --type=cache --scope=event
+      - package: a=($ZTSD_MAC_RELEASE_FILES) && store-cli set ${a[2]} --type=cache --scope=event
   
   publish:
     requires: [zstd, skopeo, zstd-mac]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,7 +1,7 @@
 shared:
   image: almalinux
   environment:
-    RELEASE_FILES: "skopeo-linux.tar.gz zstd-cli-linux.tar.gz zstd-cli-macosx.tar.gz"
+    RELEASE_FILES: "skopeo-linux.tar.gz zstd-cli-linux.tar.gz zstd-cli-linux-aarch64.tar.gz zstd-cli-macosx.tar.gz"
 
 jobs:
   skopeo:
@@ -46,7 +46,7 @@ jobs:
     requires: [~pr, ~commit]
     environment:
       ZSTD_PACKAGE: zstd
-      ZSTD_VERSION: 1.5.0
+      ZSTD_VERSION: 1.5.6
     steps:
       - make: |
           yum install -y epel-release


### PR DESCRIPTION
## Context

publish aarch64 version for ztsd cli

## Objective

This PR publishes ztsd aar64 version and upgrades ztsd to 1.5.6 version

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
