### PR TITLE
fix: restrict PR run on fork

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,6 +2,9 @@ shared:
   environment:
     RELEASE_FILES: "skopeo-linux.tar.gz zstd-cli-linux.tar.gz zstd-cli-linux-aarch64.tar.gz zstd-cli-macosx.tar.gz skopeo-linux-aarch64.tar.gz"
 
+annotations:
+  screwdriver.cd/restrictPR: fork
+
 jobs:
   skopeo:
     requires: [~pr, ~commit]


### PR DESCRIPTION
## Context

For security from any possible attack like this https://github.com/screwdriver-cd/sd-packages/pull/16, we should not allow fork PR to run. 

## Objective

Turn on restrict fork

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
